### PR TITLE
Initial Python websocket-client to the Resourcer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+Its recommended to setup a virtual environment, e.g. `virtualenv venv`.
+
+Then do `pip install requirements.txt`
+
 You will need the following env vars set. In Prod, these would be passed in via Beep Boop.
 
 `export BEEPBOOP_TOKEN=foo`
@@ -10,4 +14,5 @@ You will need the following env vars set. In Prod, these would be passed in via 
 
 `export BEEPBOOP_RESOURCER=ws://localhost:9000/ws` -- recommend using the [Beep Boop dev-console](https://github.com/BeepBoopHQ/dev-console) and setting this value to it.
 
-Run `python ./examples/simple.py` which registers listeners as a consuming app might.
+Run `python ./examples/simple.py` which registers listeners as a consuming app might.  Note you may need to set `export PYTHONPATH=.` so that
+it can properly import the beepboop module.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 WIP - Not ready for use.
+
+* Development
+
+You will need the following env vars set. In Prod, these would be passed in via Beep Boop.
+`export BEEPBOOP_TOKEN=foo`
+`export BEEPBOOP_ID=bar`
+`export BEEPBOOP_RESOURCER=ws://localhost:9000/ws` -- recommend using the [Beep Boop dev-console](https://github.com/BeepBoopHQ/dev-console) and setting this value to it.
+
+Run `python ./examples/simple.py` which registers listeners as a consuming app might.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-WIP - Not ready for use.
+# WIP - Not ready for use.
 
-* Development
+## Development
 
 You will need the following env vars set. In Prod, these would be passed in via Beep Boop.
+
 `export BEEPBOOP_TOKEN=foo`
+
 `export BEEPBOOP_ID=bar`
+
 `export BEEPBOOP_RESOURCER=ws://localhost:9000/ws` -- recommend using the [Beep Boop dev-console](https://github.com/BeepBoopHQ/dev-console) and setting this value to it.
 
 Run `python ./examples/simple.py` which registers listeners as a consuming app might.

--- a/beepboop.py
+++ b/beepboop.py
@@ -1,0 +1,90 @@
+# -*- coding: utf8 -*-
+
+from __future__ import print_function
+import os
+import json
+import time
+import sys
+
+import logging
+
+log_level = os.getenv("LOG_LEVEL", "INFO")
+logging.basicConfig(format='%(asctime)s - %(levelname)s: %(message)s', level=log_level)
+logger = logging.getLogger(__name__)
+
+sys.path.append('/Users/skud/projects/src/github.com/BeepBoopHQ/websocket-client')
+import websocket
+
+
+class BeepBoop(object):
+    def __init__(self, token=None, pod_id=None, resourcer=None):
+        self.token = self._getprop(token, "BEEPBOOP_TOKEN")
+        self.pod_id = self._getprop(pod_id, "BEEPBOOP_ID")
+        self.resourcer = self._getprop(resourcer, "BEEPBOOP_RESOURCER")
+
+        self.ws_conn = None
+        self.ws_app = None
+        self.handler_funcs = None
+        self.iter = 0
+
+    def start(self):
+        logging.info('Connecting to Beep Boop Resourcer server: ' + self.resourcer)
+
+        ws_app = websocket.WebSocketApp(self.resourcer,
+                                  on_message = self.on_message,
+                                  on_error = self.on_error,
+                                  on_close = self.on_close)
+
+        ws_app.on_open = self.on_open
+        self.ws_app = ws_app
+        self._connect()
+
+    # sets handlers "registered" by the client, enabling the bubbling up of events
+    def handlers(self, handler_funcs_dict):
+        self.handler_funcs = handler_funcs_dict
+
+    def _connect(self):
+        self.iter += 1
+        print ('iteration: ' + str(self.iter))
+        self.ws_app.run_forever()
+
+    def on_message(self, ws, message):
+        if self.handler_funcs['on_message']:
+            self.handler_funcs['on_message'](ws, json.loads(message))
+
+    def on_error(self, ws, error):
+        if self.handler_funcs['on_error']:
+            self.handler_funcs['on_error'](ws, error)
+
+    def on_close(self, ws):
+        if self.handler_funcs['on_close']:
+            self.handler_funcs['on_close'](ws)
+
+        # must be connected to the resourcer so we need to keep "retrying".
+        # NOTE: websocket lib should handle cleanup but i'm seeing leaking
+        time.sleep(1)
+        self._connect()
+
+    def on_open(self, ws):
+        self.ws_conn = ws
+        self._authorize()
+        if self.handler_funcs['on_open']:
+            self.handler_funcs['on_open'](ws)
+
+
+
+    def _authorize(self):
+        auth_msg = dict([
+            ('type', 'auth'),
+            ('id', self.pod_id),
+            ('token', self.token),
+        ])
+        self.ws_conn.send(json.dumps(auth_msg))
+
+    def _getprop(self, param, env_var):
+        v = param or os.getenv(env_var, None)
+        if not v:
+            logging.fatal('Missing required environment variable ' + env_var)
+            exit()
+
+        return v

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import sys
 import os
 import pprint
-sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 import beepboop
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+import sys
+import os
+import pprint
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+import beepboop
+
+if __name__ == "__main__":
+
+    # Fires when a data-transfer type of message has been sent from the Beep Boop Resourcer server.
+    # The following "types" of messages are supported:
+    #   add_resource - a request to add a bot instance to a team has been received.
+    #   update_resource - a request to update an instance of a bot has been received (config changed)
+    #   remove_resource - a request to remove a bot instance from a team has been received.
+
+    # The message has the following (prettyprint) form:
+    #   {
+    #     u'date': u'2016-03-01T15:06:20.471155964-07:00',
+    #     u'msgID': u'00a6d8e1-2f83-439e-9a1c-f9537c8ba0d3',
+    #     u'resource': { u'MY_CUSTOM_CONFIG_NAME': u'the peanuts are friendly'},
+    #     u'resourceID': u'ec4fba40-1e89-4005-a236-4f6f77ef19ca',
+    #     u'type': u'add_resource'
+    #   }
+
+    def on_message(ws, message):
+
+        # Access the message type
+        print (message['type'])
+
+        # Access the config defined in the bot.yml (commented avoid error)
+        # print (message['resource']['MY_CUSTOM_CONFIG'])
+
+        pp = pprint.PrettyPrinter(indent=2)
+        pp.pprint(message)
+
+
+    # Fires when an error occurred in the connection with the Beep Boop Resourcer server.
+    def on_error(ws, error):
+        print ('Error: ' + str(error))
+
+    # Fires the connection with the Beep Boop resourcer has closed.
+    def on_close(ws):
+        print ('Closed')
+
+    # Fires when the connection with the Beep Boop resourcer has opened.
+    def on_open(ws):
+        print('Opened')
+
+
+    # handler_funcs allows you to declare the events you want to listen for and their handlers
+    handler_funcs = dict([
+            ('on_open', on_open),
+            ('on_message', on_message),
+            ('on_error', on_error),
+            ('on_close', on_close),
+        ])
+
+    bp = beepboop.BeepBoop()
+    bp.handlers(handler_funcs)
+    bp.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-websocket-client>=0.22.0
+six==1.10.0
+websocket-client==0.35.0
+wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+websocket-client>=0.22.0


### PR DESCRIPTION
#### What's this PR do?

Uses the websocket-client module to handle connections to the resourcer and a framework for handling the connection and forwarding messages on to the bot app that will use this connection.
#### Where should the reviewer start?

See changelist.
#### How should this be manually tested?

Follow instructions in README, start sample app.  Also `export LOG_LEVEL=DEBUG`.  Stop dev-console process, verify that the app client tries to reconnect in a randomized exponential backoff fashion, with max retry backoff at 32 seconds.
#### Any background context you want to provide?

Made the change to get the retry open websocket connection on close from:
https://github.com/liris/websocket-client/issues/95
#### Screenshots (if appropriate)

http://i.imgur.com/8dVeY.jpg
