### PR TITLE
Multi Bot Registry and Daemon Thread Wrappers

### DIFF
--- a/beepboop.py
+++ b/beepboop.py
@@ -5,6 +5,7 @@ import os
 import json
 import time
 import sys
+import threading
 
 import logging
 
@@ -15,9 +16,16 @@ logger = logging.getLogger(__name__)
 import websocket
 import random
 
+ # Use binary exponential backoff to desynchronize client requests.
+ # As described by: https://cloud.google.com/storage/docs/exponential-backoff
+def expBackoffSleep(n, max_backoff_time):
+    time_to_sleep = min(random.random() * (2**n), max_backoff_time)
+    logging.debug('time to sleep: ' + str(time_to_sleep))
+    time.sleep(time_to_sleep)
+
 
 class BeepBoop(object):
-    def __init__(self, token=None, pod_id=None, resourcer=None):
+    def __init__(self, spawn_bot, token=None, pod_id=None, resourcer=None):
         self.token = self._getprop(token, "BEEPBOOP_TOKEN")
         self.pod_id = self._getprop(pod_id, "BEEPBOOP_ID")
         self.resourcer = self._getprop(resourcer, "BEEPBOOP_RESOURCER")
@@ -26,6 +34,9 @@ class BeepBoop(object):
         self.ws_app = None
         self.handler_funcs = None
         self.iter = 0
+
+        self.spawn_bot = spawn_bot
+        self.resources = BotResources()
 
     def start(self):
         logging.info('Connecting to Beep Boop Resourcer server: ' + self.resourcer)
@@ -43,7 +54,6 @@ class BeepBoop(object):
     def handlers(self, handler_funcs_dict):
         self.handler_funcs = handler_funcs_dict
 
-    
     def _connect(self):
         # while loop makes sure we retry to connect on server down or network failure
         while True:
@@ -52,10 +62,11 @@ class BeepBoop(object):
             logging.debug('reconnecting attempt: ' + str(self.iter))
             expBackoffSleep(self.iter, 32)
 
-
     def on_message(self, ws, message):
+        msg = json.loads(message)
         if self.handler_funcs['on_message']:
-            self.handler_funcs['on_message'](ws, json.loads(message))
+            self.handler_funcs['on_message'](ws, msg)
+        self._handle_message(ws, msg)
 
     def on_error(self, ws, error):
         if self.handler_funcs['on_error']:
@@ -73,7 +84,15 @@ class BeepBoop(object):
         if self.handler_funcs['on_open']:
             self.handler_funcs['on_open'](ws)
 
-
+    def _handle_message(self, ws, msg):
+        if msg['type'] == 'add_resource':
+            self.resources.add_bot_resource(msg, self.spawn_bot)
+        elif msg['type'] == 'update_resource':
+            self.resources.update_bot_resource(msg, self.spawn_bot)
+        elif msg['type'] == 'remove_resource':
+            self.resources.remove_bot_resource(msg['resourceID'])
+        else:
+            logging.warn('Unhandled Resource messsage type: {}'.format(msg['type']))
 
     def _authorize(self):
         auth_msg = dict([
@@ -91,9 +110,59 @@ class BeepBoop(object):
 
         return v
 
- # Use binary exponential backoff to desynchronize client requests.
- # As described by: https://cloud.google.com/storage/docs/exponential-backoff
-def expBackoffSleep(n, max_backoff_time):
-    time_to_sleep = min(random.random() * (2**n), max_backoff_time)
-    logging.debug('time to sleep: ' + str(time_to_sleep))
-    time.sleep(time_to_sleep)
+
+class BotResources(object):
+    def __init__(self):
+        self.resources = {}
+
+    def add_bot_resource(self, res, spawn_bot):
+        logging.debug("Adding bot resource: {}".format(res))
+        resID = res['resourceID']
+        runnableBot = BotRunner(spawn_bot(), res)
+        self.resources[resID] = runnableBot
+        runnableBot.start()
+
+    def update_bot_resource(self, res, spawn_bot):
+        logging.debug("Updating bot res: {}".format(res))
+        if res['resourceID'] in self.resource:
+            self.resource[res['resourceID']] = (bot, res)
+        else:
+            logging.error("Failed to find resourceID: {} in resources to update.".format(res['resourceID']))
+
+    def get_bot_resource(self, resID):
+        logging.debug("Getting bot resource for resID: {}".format(resID))
+        return self.resources[resID]
+
+    def remove_bot_resource(self, resID):
+        logging.debug("Removing bot resource for resID: {}".format(resID))
+        if resID in self.resources:
+            self.resources[resID].stop()
+            del self.resources[resID]
+        else:
+            logging.error("Failed to find resID: {} in resources to remove.".format(resID))
+
+
+class BotRunner(threading.Thread):
+    def __init__(self, bot, resource):
+        self._stopevent = threading.Event()
+        self._sleepperiod = 0.100 # 100 ms
+        threading.Thread.__init__(self)
+        self.setDaemon(True) # thread will stop if main process is killed
+        self.bot = bot
+        self.resource = resource
+
+    def run(self):
+        logging.debug("Starting Bot: {} for Resource: {}".format(self.bot, self.resource))
+        self.bot.start(self.resource)
+        while not self._stopevent.isSet():
+            logging.debug("Waiting for Bot thread interrupt on ResourceID: {}".format(self.resource['resourceID']))
+            self._stopevent.wait(self._sleepperiod)
+        logging.debug("Stopped Bot: {} for Resource: {}".format(self.bot, self.resource))
+
+    def stop(self, timeout=None):
+        logging.debug("Stopping Bot: {} for Resource: {}".format(self.bot, self.resource))
+        self.bot.stop(self.resource)
+        self._stopevent.set()
+        threading.Thread.join(self, timeout)
+
+

--- a/beepboop.py
+++ b/beepboop.py
@@ -124,8 +124,11 @@ class BotResources(object):
 
     def update_bot_resource(self, res, spawn_bot):
         logging.debug("Updating bot res: {}".format(res))
-        if res['resourceID'] in self.resource:
-            self.resource[res['resourceID']] = (bot, res)
+        if res['resourceID'] in self.resources:
+            self.resources[res['resourceID']].stop()
+            runnableBot = BotRunner(spawn_bot(), res)
+            self.resources[res['resourceID']] = runnableBot
+            runnableBot.start()
         else:
             logging.error("Failed to find resourceID: {} in resources to update.".format(res['resourceID']))
 
@@ -145,7 +148,7 @@ class BotResources(object):
 class BotRunner(threading.Thread):
     def __init__(self, bot, resource):
         self._stopevent = threading.Event()
-        self._sleepperiod = 0.100 # 100 ms
+        self._sleepperiod = 1.0 # 1 second
         threading.Thread.__init__(self)
         self.setDaemon(True) # thread will stop if main process is killed
         self.bot = bot

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,9 +1,27 @@
-from __future__ import print_function
+#from __future__ import print_function
 import sys
 import os
 import pprint
 
 import beepboop
+
+def spawn_bot():
+    return MockBot()
+
+class MockBot(object):
+    def __init__(self):
+        self.resource = None
+
+    def start(self, resource):
+        self.resource = resource
+        print "Started Bot for ResourceID: {}".format(self.resource['resourceID'])
+        # this is where you'd setup your websocket rtm connection to Slack using token
+
+    def stop(self, resource):
+        print "Stopped Bot for ResourceID: {}".format(self.resource['resourceID'])
+        self.resource = None
+        # this is where you'd close your Slack socket connection, and save any context or data
+
 
 if __name__ == "__main__":
 
@@ -55,6 +73,6 @@ if __name__ == "__main__":
             ('on_close', on_close),
         ])
 
-    bp = beepboop.BeepBoop()
+    bp = beepboop.BeepBoop(spawn_bot)
     bp.handlers(handler_funcs)
     bp.start()

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -6,9 +6,9 @@ import pprint
 import beepboop
 
 def spawn_bot():
-    return MockBot()
+    return SampleBot()
 
-class MockBot(object):
+class SampleBot(object):
     def __init__(self):
         self.resource = None
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -73,6 +73,11 @@ if __name__ == "__main__":
             ('on_close', on_close),
         ])
 
-    bp = beepboop.BeepBoop(spawn_bot)
+    # optional to use our bot manager to spawn instances of your bot in daemon threads;
+    # bot developer can choose instead to listen to the websockect messages above and
+    # write their own bot per resource manager or integrate with a 3rd party client that does
+    botManager = beepboop.BotManager(spawn_bot)
+
+    bp = beepboop.BeepBoop(botManager)
     bp.handlers(handler_funcs)
     bp.start()


### PR DESCRIPTION
#### What's this PR do?

Adds BotResources (resourceID > runnableBot) and BotRunner (bot/resource thread) to the BeepBoop module as a way to manage and create new Bot instances per resource added from the Resourcer websocket connection.  All to try and support the multi-team bot use case for Python bots.
#### Where should the reviewer start?

beepboop.py:

> BotResources class (dictionary of resourceID to instance of BotRunner)
> BotRunner class (daemon thread instance that expects Bot instance with start() and stop() methods)
> BeepBoop class - modification to onMessage to call _handleMessage which spawns BotRunner and stores it in BotResources.

examples/simple.py:

> MockBot class that implements expected start() and stop() interface
> spawn_bot function that creates a new MockBot instance which is passed into BeepBoop instance which is used to to create a new Bot instance when we receive an add_resource or update_resource message from Resourcer.
#### How should this be manually tested?

Start dev-console server via `make run`

In another terminal, `export LOG_LEVEL=DEBUG`
Start example app: `python ./examples/simple.py`
Verify connection to dev-console server established.

Open `localhost:9000` dev console web view, and add a resource.
Verify that we spawned a bot for that resourceID and we are checking every second to see if its removed.

Update that resource and verify we stop that Bot instance and spawn a new Bot instance with the updated resource.

Remove that resource and verify the Bot stops.

Add as many resources as you want and verify that a bot spawns for each one and when you remove one, it stops the correct bot associated to that instance.
#### Any background context you want to provide?

setDaemon(True) in the thread makes sure that when the app itself is killed, any children thread are also killed and don't continue running in the background.
#### Screenshots (if appropriate)

Example console output:

```
2016-03-17 20:05:39,592 - INFO: Connecting to Beep Boop Resourcer server: ws://localhost:9000/ws
Opened
auth_result
{ u'date': u'2016-03-17T20:05:39.595650697-06:00',
  u'msgID': u'fecd04e6-025f-4678-a8ab-fcfcfcf1f956',
  u'success': True,
  u'type': u'auth_result'}
2016-03-17 20:05:39,596 - WARNING: Unhandled Resource messsage type: auth_result
add_resource
{ u'date': u'2016-03-17T20:05:48.309670493-06:00',
  u'msgID': u'b4d112e3-fe26-4291-a3f7-de52300f573e',
  u'resource': { u'joe': u'schmoe'},
  u'resourceID': u'1wn5xrsh5mi',
  u'type': u'add_resource'}
2016-03-17 20:05:48,311 - DEBUG: Adding bot resource: {u'date': u'2016-03-17T20:05:48.309670493-06:00', u'msgID': u'b4d112e3-fe26-4291-a3f7-de52300f573e', u'resource': {u'joe': u'schmoe'}, u'type': u'add_resource', u'resourceID': u'1wn5xrsh5mi'}
2016-03-17 20:05:48,312 - DEBUG: Starting Bot: <__main__.MockBot object at 0x102e491d0> for Resource: {u'date': u'2016-03-17T20:05:48.309670493-06:00', u'msgID': u'b4d112e3-fe26-4291-a3f7-de52300f573e', u'resource': {u'joe': u'schmoe'}, u'type': u'add_resource', u'resourceID': u'1wn5xrsh5mi'}
Started Bot for ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:48,312 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:49,316 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:50,320 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:51,322 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:52,326 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:53,329 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:54,333 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:55,334 - DEBUG: Waiting for Bot thread interrupt on ResourceID: 1wn5xrsh5mi
remove_resource
{ u'date': u'2016-03-17T20:05:55.549205451-06:00',
  u'msgID': u'5443c490-efd9-436c-9348-919f36d14cd0',
  u'resourceID': u'1wn5xrsh5mi',
  u'type': u'remove_resource'}
2016-03-17 20:05:55,549 - DEBUG: Removing bot resource for resID: 1wn5xrsh5mi
2016-03-17 20:05:55,550 - DEBUG: Stopping Bot: <__main__.MockBot object at 0x102e491d0> for Resource: {u'date': u'2016-03-17T20:05:48.309670493-06:00', u'msgID': u'b4d112e3-fe26-4291-a3f7-de52300f573e', u'resource': {u'joe': u'schmoe'}, u'type': u'add_resource', u'resourceID': u'1wn5xrsh5mi'}
Stopped Bot for ResourceID: 1wn5xrsh5mi
2016-03-17 20:05:55,559 - DEBUG: Stopped Bot: <__main__.MockBot object at 0x102e491d0> for Resource: {u'date': u'2016-03-17T20:05:48.309670493-06:00', u'msgID': u'b4d112e3-fe26-4291-a3f7-de52300f573e', u'resource': {u'joe': u'schmoe'}, u'type': u'add_resource', u'resourceID': u'1wn5xrsh5mi'}
^CClosed
Traceback (most recent call last):
  File "./examples/simple.py", line 78, in <module>
    bp.start()
  File "/Users/barnhart/Dev/RnP/BeepBoop/src/github.com/RobotsAndPencils/beepboop-py/beepboop.py", line 51, in start
    self._connect()
  File "/Users/barnhart/Dev/RnP/BeepBoop/src/github.com/RobotsAndPencils/beepboop-py/beepboop.py", line 60, in _connect
    self.ws_app.run_forever()
  File "/Users/barnhart/Dev/RnP/BeepBoop/src/github.com/RobotsAndPencils/beepboop-py/venv/lib/python2.7/site-packages/websocket/_app.py", line 188, in run_forever
    r, w, e = select.select((self.sock.sock, ), (), (), ping_timeout)
KeyboardInterrupt
```
#### Does the change have adequate test coverage ?

Need to figure out how to add some unit tests around these classes, but wanted to get this in so that we can get feedback from our friend argparse in the Beep Boop HQ team.
